### PR TITLE
Fix release workflow sed command and tag pattern

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
   contents: write
@@ -32,11 +33,16 @@ jobs:
     
     - name: Extract version from tag
       id: get_version
-      run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+      run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
     
     - name: Update version in build.gradle.kts
       run: |
-        sed -i 's/version = ".*"/version = "${{ steps.get_version.outputs.VERSION }}"/' build.gradle.kts
+        echo "Current version before update:"
+        grep 'version = ' build.gradle.kts
+        echo "Updating to version: ${{ steps.get_version.outputs.VERSION }}"
+        sed -i.bak 's|version = ".*"|version = "${{ steps.get_version.outputs.VERSION }}"|' build.gradle.kts
+        echo "Version after update:"
+        grep 'version = ' build.gradle.kts
     
     - name: Run quality checks
       run: ./gradlew qualityCheck


### PR DESCRIPTION
## Summary

This PR fixes issues in the GitHub Actions release workflow:

## Changes Made

1. **Fix sed command syntax error**
   - Changed delimiter from `/` to `|` in sed command to avoid conflicts with slashes in version strings
   - Added debug output to show version before and after update
   - Added backup file creation (`.bak`) for safety

2. **Update tag pattern**
   - Changed tag trigger pattern to `[0-9]+.[0-9]+.[0-9]+` (without 'v' prefix)
   - This makes it more convenient for Gradle plugin users who don't need to specify 'v' prefix in version

## Technical Details

**Before:**
```yaml
sed -i 's/version = ".*"/version = "${{ steps.get_version.outputs.VERSION }}"/' build.gradle.kts
```

**After:**
```yaml
sed -i.bak 's|version = ".*"|version = "${{ steps.get_version.outputs.VERSION }}"|' build.gradle.kts
```

The original sed command failed when the version string contained forward slashes (e.g., `refs/tags/0.0.1`), causing a syntax error.

## Testing

The sed command has been tested locally and works correctly with version strings containing slashes.
