### PR TITLE
Fix Gradle 4 compatibility issue with JacocoCoverageExtension

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "io.github.mas0061"
-version = "0.0.1"
+version = "0.0.2"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/src/main/kotlin/io/github/mas0061/jacoco/JacocoCoverageConsolePlugin.kt
+++ b/src/main/kotlin/io/github/mas0061/jacoco/JacocoCoverageConsolePlugin.kt
@@ -7,6 +7,11 @@ class JacocoCoverageConsolePlugin : Plugin<Project> {
     override fun apply(project: Project) {
         val extension = project.extensions.create("jacocoCoverageConsole", JacocoCoverageExtension::class.java)
 
+        // デフォルトのCSVレポートパスを設定
+        extension.csvReportPath.convention(
+            project.file("build/reports/jacoco/test/jacocoTestReport.csv"),
+        )
+
         project.tasks.register("jacocoCoverageConsole", JacocoCoverageTask::class.java).configure {
             this.extension = extension
         }

--- a/src/main/kotlin/io/github/mas0061/jacoco/JacocoCoverageExtension.kt
+++ b/src/main/kotlin/io/github/mas0061/jacoco/JacocoCoverageExtension.kt
@@ -20,7 +20,7 @@ import javax.inject.Inject
  * }
  * ```
  */
-abstract class JacocoCoverageExtension
+open class JacocoCoverageExtension
     @Inject
     constructor(private val objects: ObjectFactory) {
         /**
@@ -28,7 +28,7 @@ abstract class JacocoCoverageExtension
          *
          * 指定しない場合は、デフォルトパス `build/reports/jacoco/test/jacocoTestReport.csv` が使用されます。
          */
-        abstract val csvReportPath: Property<File>
+        val csvReportPath: Property<File> = objects.property(File::class.java)
 
         /**
          * 全体のカバレッジ（Total行）を表示するかどうか
@@ -38,7 +38,7 @@ abstract class JacocoCoverageExtension
          * - true: Total行を表示
          * - false: 個別のクラス/パッケージのみ表示
          */
-        abstract val showTotal: Property<Boolean>
+        val showTotal: Property<Boolean> = objects.property(Boolean::class.java)
 
         /**
          * 特定のクラス/パッケージのカバレッジを表示する際のターゲット

--- a/src/test/kotlin/io/github/mas0061/jacoco/JacocoCoverageExtensionTest.kt
+++ b/src/test/kotlin/io/github/mas0061/jacoco/JacocoCoverageExtensionTest.kt
@@ -33,10 +33,11 @@ class JacocoCoverageExtensionTest {
         // エクステンションクラスが適切な構造を持っていることを確認
         val extensionClass = JacocoCoverageExtension::class.java
 
-        // abstractクラスであることを確認
+        // openクラスであることを確認（Gradle 4との互換性のためabstractからopenに変更）
         assertTrue(
-            "Extension should be abstract",
-            java.lang.reflect.Modifier.isAbstract(extensionClass.modifiers),
+            "Extension should be open class",
+            !java.lang.reflect.Modifier.isAbstract(extensionClass.modifiers) &&
+                !java.lang.reflect.Modifier.isFinal(extensionClass.modifiers),
         )
 
         // JacocoCoverageExtensionクラスが存在することを確認

--- a/test-project/build.gradle.kts
+++ b/test-project/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("jacoco")
-    id("io.github.mas0061.jacoco-coverage-console") version "0.0.1"
+    id("io.github.mas0061.jacoco-coverage-console") version "0.0.2"
 }
 
 group = "com.example"


### PR DESCRIPTION
## Summary
• Fix Gradle 4.5.1 compatibility issue reported in #7
• Convert JacocoCoverageExtension from abstract class to open class with ObjectFactory-initialized properties

## Test plan
- [x] Build and test with current Gradle version (8.x)
- [x] Publish to local repository and test with test-project
- [x] Verify plugin functionality works as expected
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)