### PR TITLE
Fix: Add project property support for Gradle 4 command-line options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Project property support for Gradle 4 compatibility
+  - Use `-PjacocoClasses=...` for class filtering in Gradle 4
+  - Use `-PjacocoCsvPath=...` for custom CSV path in Gradle 4
+  - Maintains backward compatibility with `--classes` and `--csv-path` options in Gradle 5+
+
+### Changed
+- Improved parameter handling with fallback mechanism for older Gradle versions
+- Updated documentation to clarify Gradle version-specific usage
+
+## [0.0.3] - 2025-06-05
+
+### Changed
+- Simplified configuration API for better Gradle 4 compatibility
+  - Changed from `.set()` methods to direct assignment (`=`)
+  - Example: `showTotal = true` instead of `showTotal.set(true)`
+
+### Fixed
+- Gradle 4 compatibility issues with extension configuration
+
+## [0.0.2] - 2025-06-03
+
+### Fixed
+- Fixed compatibility issues with various Gradle versions
+
 ## [0.0.1] - 2025-06-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ jacocoCoverageConsole {
 ```
 
 ### Command Line Options
+
+#### Gradle 5+ (Using --options)
 ```bash
 # Specific classes
 ./gradlew jacocoCoverageConsole --classes=com.example.service.*
@@ -98,6 +100,20 @@ jacocoCoverageConsole {
 # Multiple targets  
 ./gradlew jacocoCoverageConsole --classes=com.example.service.*,com.example.controller.UserController
 ```
+
+#### Gradle 4 (Using -P project properties)
+```bash
+# Specific classes
+./gradlew jacocoCoverageConsole -PjacocoClasses=com.example.service.*
+
+# Custom CSV file
+./gradlew jacocoCoverageConsole -PjacocoCsvPath=custom/path/report.csv
+
+# Multiple targets  
+./gradlew jacocoCoverageConsole -PjacocoClasses=com.example.service.*,com.example.controller.UserController
+```
+
+> **Note**: Gradle 4 does not support the `@Option` annotation, so project properties must be used instead.
 
 ### JaCoCo CSV Report Setup
 


### PR DESCRIPTION
## Summary
- Add project property support to enable command-line options in Gradle 4
- Implement fallback mechanism for older Gradle versions that don't support @Option annotation
- Update documentation with version-specific usage instructions

## Background
Gradle 4 does not support the `@Option` annotation for custom tasks, which caused the `--classes` parameter to fail with "Unknown command-line option" error as reported in #11.

## Solution
This PR adds support for project properties as an alternative to command-line options:
- Gradle 5+: Use `--classes` and `--csv-path` (existing behavior)
- Gradle 4: Use `-PjacocoClasses` and `-PjacocoCsvPath` (new fallback)

The implementation maintains backward compatibility while extending support to Gradle 4 users.

## Changes
1. **CoverageConfigurationManager.kt**:
   - Added project property checks in `determineCsvFile()` and `determineTargetClasses()`
   - Implemented priority order: CLI options → Project properties → Extension config → Defaults

2. **Documentation Updates**:
   - README.md: Added Gradle version-specific usage examples
   - CHANGELOG.md: Documented the new feature

## Testing
Tested with both Gradle 4 and Gradle 8:
- ✅ Gradle 8: `--classes` option works as expected
- ✅ Gradle 4: `-PjacocoClasses` property works correctly
- ✅ Multiple class patterns supported in both versions

## Example Usage

### Gradle 5+
```bash
./gradlew jacocoCoverageConsole --classes=com.example.service.*
```

### Gradle 4
```bash
./gradlew jacocoCoverageConsole -PjacocoClasses=com.example.service.*
```

Fixes #11

## Test plan
- [x] Test with Gradle 4 using project properties
- [x] Test with Gradle 8 using command-line options
- [x] Verify backward compatibility
- [x] Test multiple class patterns
- [x] Update documentation

🤖 Generated with [Claude Code](https://claude.ai/code)